### PR TITLE
Update github actions workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -14,18 +14,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18]
+        node: [20]
 
     runs-on: ${{ matrix.os }}
 
     steps:
     # checkout the repo
     - name: Checkout the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # use node.js matrix
     - name: Use Node.js ${{ matrix.node }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
 


### PR DESCRIPTION
- update actions/checkout to v4
- update actions/setup-node to v4
- update node version to v20, lts/iron
